### PR TITLE
Прокидывать ошибку из makefile в js-check

### DIFF
--- a/bin/js-check
+++ b/bin/js-check
@@ -1,5 +1,7 @@
 #!/bin/bash
 
 echo "include /usr/lib/node_modules/livetex-tools/rules/js.mk" > Makefile
-make js-check || true
+make js-check
+MAKE_EXIT_CODE=$?
 rm Makefile
+exit $MAKE_EXIT_CODE

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "livetex-tools",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/LiveTex/Livetex-Tools"


### PR DESCRIPTION
чтобы teamcity не исполнял шаги, если js-check не проходит
